### PR TITLE
add support for protocol-relative URLs

### DIFF
--- a/tasks/appcache.js
+++ b/tasks/appcache.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
 	}
 
 	function isAbsolutePath(path) {
-		return (/^https?:\/\//i).test(path);
+		return (/^(?:https?:)?\/\//i).test(path);
 	}
 
 	function expand(input) {


### PR DESCRIPTION
I typically include scripts from the Google CDN in my projects, e.g. `<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.min.js"></script>`, and their recommended practice is protocol-relative URLs, which help in situations where the client can choose to load resources over HTTP or HTTPS. I noticed grunt-appcache wasn't including the CDN files in the manifest, however.

This commit fixes a bug in `isAbsolutePath`, which returns false for an absolute URL like '//cdn.com/lib.js'. It just makes the http(s) optional when it tests the beginning of the path.
